### PR TITLE
fix: resolve race conditions in TerminateSignal and update documentation

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,138 @@
+# the name by which the project can be referenced within Serena
+project_name: "gs"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- go
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-English | [中文](./README_CN.md)
-
 <div align="center">
 	<img src="assets/logo.png" alt="logo" width="450px">
 </div>
@@ -7,190 +5,340 @@ English | [中文](./README_CN.md)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shengyanli1982/gs)](https://goreportcard.com/report/github.com/shengyanli1982/gs)
 [![Build Status](https://github.com/shengyanli1982/gs/actions/workflows/test.yaml/badge.svg)](https://github.com/shengyanli1982/gs/actions)
 [![Go Reference](https://pkg.go.dev/badge/github.com/shengyanli1982/gs.svg)](https://pkg.go.dev/github.com/shengyanli1982/gs)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/shengyanli1982/gs)](https://golang.org/doc/go1.19)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/shengyanli1982/gs)
 
-# Introduction
+# GS - Graceful Shutdown
 
-**Graceful Shutdown** is a common requirement for most services. It is considered a best practice to gracefully shut down a service when it receives a termination signal. The process of graceful shutdown typically involves the following steps:
-
-1. Create a `TerminateSignal` instance and register the desired termination signal.
-2. Register the resources that need to be closed when the service is terminated.
-3. Use the `WaitForAsync`, `WaitForSync`, or `WaitForForceSync` method to wait for the `TerminateSignal` instance to gracefully shut down.
+**GS** is a lightweight Go library for implementing graceful shutdown in your services. It provides a clean API to handle OS termination signals and coordinate the shutdown of multiple resources.
 
 > [!IMPORTANT]
 >
-> It is strongly recommended to use the latest stable version of the library after **v0.1.3**. Previous versions have significant logic and control issues and are no longer recommended.
+> This library is recommended for production use. Previous versions (< v0.2.0) had significant logic and concurrency issues and are no longer maintained.
 
-# Advantages
+## Features
 
--   Simple and user-friendly
--   No external dependencies required
--   Low memory footprint
--   Supports timeout signals
--   Supports context
--   Supports multiple signals
+- **Simple API** - Minimal setup required
+- **Zero dependencies** - No external packages needed
+- **Concurrent-safe** - Thread-safe handler registration and execution
+- **Context support** - Integrate with Go's context propagation
+- **Multiple signals** - Handle SIGINT, SIGTERM, and SIGQUIT
+- **Flexible shutdown modes** - Async, sync, and force-sync execution
 
-# Installation
+## Installation
 
 ```bash
 go get github.com/shengyanli1982/gs
 ```
 
-# Quick Start
-
-`GS` is a simple and easy-to-use library for graceful shutdown. To use it, follow these steps:
-
-1. Create a `TerminateSignal` instance.
-2. Register the resources that need to be closed when the service is terminated.
-3. Use the appropriate waiting method (`WaitForAsync`, `WaitForSync`, or `WaitForForceSync`) to wait for the `TerminateSignal` instance to gracefully shut down.
-
-> [!IMPORTANT]
->
-> If you are using `GS` on `Windows`, make sure to use it with a `console` application.
-
-### Methods
-
-**Create**
-
--   `NewTerminateSignal`: Create a new `TerminateSignal` instance.
--   `NewTerminateSignalWithContext`: Create a new `TerminateSignal` instance with context.
-
-**TerminateSignal**
-
--   `RegisterCancelHandles`: Register the resources that need to be closed when the service is terminated.
--   `GetStopContext`: Get the context of the `TerminateSignal` instance.
--   `Close`: Close the `TerminateSignal` instance asynchronously.
--   `SyncClose`: Close the `TerminateSignal` instance synchronously.
-
-**Waiting**
-
--   `WaitForAsync`: Wait for the `TerminateSignal` instance to gracefully shut down asynchronously.
--   `WaitForSync`: Wait for the `TerminateSignal` instance to gracefully shut down synchronously.
--   `WaitForForceSync`: Wait for the `TerminateSignal` instance to gracefully shut down strict synchronously.
-
-> [!NOTE]
->
-> **Differences between `synchronously (SyncClose)` and `strict synchronously (ForceSyncClose)`**
->
-> ```go
-> // SyncClose 表示同步关闭，即在不同的 TerminateSignal 中同步执行关闭操作, eg: t1.Close() then t2.Close() then t3.Close()
-> // 在每个 TerminateSignal 中，是异步执行的
-> // SyncClose represents synchronous closure, i.e., the closure operation is performed synchronously in different TerminateSignal, eg: t1.Close() then t2.Close() then t3.Close()
-> // In each TerminateSignal, it is asynchronous
-> SyncClose
->
-> // ForceSyncClose 表示强制同步关闭，即在不同的 TerminateSignal 中同步执行关闭操作, eg: t1.Close() then t2.Close() then t3.Close()
-> // 在每个 TerminateSignal 中，是完全同步执行的
-> // ForceSyncClose represents forced synchronous closure, i.e., the closure operation is performed synchronously in different TerminateSignal, eg: t1.Close() then t2.Close() then t3.Close()
-> // In each TerminateSignal, it is completely synchronous
-> ForceSyncClose
-> ```
->
-> `ForceSyncClose` is completely synchronous, while `SyncClose` is asynchronous in each `TerminateSignal`.
-
-> [!IMPORTANT]
->
-> The `WaitingForGracefulShutdown` method is deprecated since v0.1.3. It is recommended to use the `WaitForAsync`, `WaitForSync`, or `WaitForForceSync` methods instead.
-
-### Example
-
-> [!TIP]
->
-> The `os.Process.Signal()` method only works on Linux and MacOS, and is invalid for Windows. If you want to test the code on Windows, please refer to the `gracefull_windows_test.go` code.
+## Quick Start
 
 ```go
 package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
 	"github.com/shengyanli1982/gs"
 )
 
-// 模拟一个服务
-// Simulate a service
-type testTerminateSignal struct{}
-
-// Close 方法用于关闭 testTerminateSignal 服务
-// The Close method is used to close the testTerminateSignal service
-func (t *testTerminateSignal) Close() {
-	fmt.Println("testTerminateSignal.Close()")
-}
-
-// 模拟一个服务
-// Simulate a service
-type testTerminateSignal2 struct{}
-
-// Shutdown 方法用于关闭 testTerminateSignal2 服务
-// The Shutdown method is used to close the testTerminateSignal2 service
-func (t *testTerminateSignal2) Shutdown() {
-	fmt.Println("testTerminateSignal2.Shutdown()")
-}
-
-// 模拟一个服务
-// Simulate a service
-type testTerminateSignal3 struct{}
-
-// Terminate 方法用于关闭 testTerminateSignal3 服务
-// The Terminate method is used to close the testTerminateSignal3 service
-func (t *testTerminateSignal3) Terminate() {
-	fmt.Println("testTerminateSignal3.Terminate()")
-}
-
 func main() {
-	// 创建一个新的 TerminateSignal 实例
-	// Create a new TerminateSignal instance
-	s := gs.NewTerminateSignal()
+	sig := gs.NewTerminateSignal()
 
-	// 创建三个测试服务的实例
-	// Create instances of three test services
-	t1 := &testTerminateSignal{}
-	t2 := &testTerminateSignal2{}
-	t3 := &testTerminateSignal3{}
+	// Register shutdown handlers
+	sig.RegisterCancelHandles(
+		func() { fmt.Println("Closing database connection...") },
+		func() { fmt.Println("Stopping HTTP server...") },
+	)
 
-	// 注册需要在终止信号发生时执行的处理函数
-	// Register the handle functions to be executed when the termination signal occurs
-	s.RegisterCancelHandles(t1.Close, t2.Shutdown, t3.Terminate)
-
-	// 在新的 goroutine 中执行一个函数
-	// Execute a function in a new goroutine
+	// Start HTTP server
+	server := &http.Server{Addr: ":8080"}
 	go func() {
-		// 等待 2 秒
-		// Wait for 2 seconds
-		time.Sleep(2 * time.Second)
-
-		// 查找当前进程
-		// Find the current process
-		p, err := os.FindProcess(os.Getpid())
-		if err != nil {
-			fmt.Println(err.Error())
-		}
-
-		// 向当前进程发送中断信号, os.Process.Signal() 对 Linux 和 MacOS 有效, Windows 无效
-		// Send an interrupt signal to the current process, os.Process.Signal() is valid for Linux and MacOS, invalid for Windows
-		err = p.Signal(os.Interrupt)
-		if err != nil {
-			fmt.Println(err.Error())
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
+			fmt.Printf("HTTP server error: %v\n", err)
 		}
 	}()
 
-	// 等待所有的异步关闭信号
-	// Wait for all asynchronous shutdown signals
-	gs.WaitForAsync(s)
+	fmt.Println("Server started. Press Ctrl+C to shutdown.")
 
-	// 打印一条消息，表示服务已经优雅地关闭
-	// Print a message indicating that the service has been gracefully shut down
-	fmt.Println("shutdown gracefully")
+	// Wait for shutdown signal (SIGINT, SIGTERM, SIGQUIT)
+	gs.WaitForAsync(sig)
+
+	// Graceful HTTP shutdown
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	server.Shutdown(ctx)
+
+	fmt.Println("Server shutdown gracefully.")
+	os.Exit(0)
 }
 ```
 
-**Result**
+## API Reference
 
-```bash
-$ go run demo.go
-testTerminateSignal3.Terminate()
-testTerminateSignal.Close()
-testTerminateSignal2.Shutdown()
-shutdown gracefully
+### Creating Termination Signals
+
+```go
+// Create a new termination signal
+sig := gs.NewTerminateSignal()
+
+// Create with context support
+sig := gs.NewTerminateSignalWithContext(ctx)
 ```
+
+### Registering Shutdown Handlers
+
+```go
+// Register one or more cleanup functions
+sig.RegisterCancelHandles(
+	cleanupFunc1,
+	cleanupFunc2,
+	cleanupFunc3,
+)
+```
+
+**Note:** Handlers are executed in the order they were registered. The registration is concurrent-safe.
+
+### Shutdown Modes
+
+GS provides three shutdown modes with different execution semantics:
+
+#### 1. Async Mode (`WaitForAsync`)
+
+- **Between signals:** Parallel execution
+- **Within each signal:** Concurrent execution (each handler in a goroutine)
+- **Use case:** Maximum throughput, order doesn't matter
+
+```go
+sig1 := gs.NewTerminateSignal()
+sig2 := gs.NewTerminateSignal()
+
+sig1.RegisterCancelHandles(handler1a, handler1b)
+sig2.RegisterCancelHandles(handler2a, handler2b)
+
+// All handlers execute concurrently
+gs.WaitForAsync(sig1, sig2)
+```
+
+#### 2. Sync Mode (`WaitForSync`)
+
+- **Between signals:** Sequential execution
+- **Within each signal:** Concurrent execution (each handler in a goroutine)
+- **Use case:** Signals need ordered shutdown, handlers can run concurrently
+
+```go
+sig1 := gs.NewTerminateSignal()
+sig2 := gs.NewTerminateSignal()
+
+// sig1 shuts down completely, then sig2
+gs.WaitForSync(sig1, sig2)
+```
+
+#### 3. Force Sync Mode (`WaitForForceSync`)
+
+- **Between signals:** Sequential execution
+- **Within each signal:** Sequential execution (handlers run one by one)
+- **Use case:** Strict ordering required at all levels
+
+```go
+sig1 := gs.NewTerminateSignal()
+sig2 := gs.NewTerminateSignal()
+
+// sig1 handlers run sequentially, then sig2 handlers
+gs.WaitForForceSync(sig1, sig2)
+```
+
+### Manual Control
+
+You can also trigger shutdown programmatically:
+
+```go
+// Async close
+sig.Close(nil)
+
+// Sync close
+sig.SyncClose(nil)
+
+// With wait group for coordination
+var wg sync.WaitGroup
+wg.Add(1)
+sig.Close(&wg)
+wg.Wait()
+```
+
+### Context Integration
+
+Access the shutdown context to coordinate with other goroutines:
+
+```go
+sig := gs.NewTerminateSignal()
+ctx := sig.GetStopContext()
+
+// Watch for shutdown in your workers
+go func() {
+	select {
+	case <-ctx.Done():
+		fmt.Println("Shutdown signal received")
+	case <-time.After(10 * time.Second):
+		fmt.Println("Timeout")
+	}
+}()
+
+gs.WaitForAsync(sig)
+```
+
+## Advanced Examples
+
+### HTTP Server with Database Connection
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/shengyanli1982/gs"
+)
+
+type Database struct {
+	connected bool
+}
+
+func (db *Database) Close() {
+	fmt.Println("Closing database connection...")
+	time.Sleep(500 * time.Millisecond)
+	db.connected = false
+	fmt.Println("Database closed.")
+}
+
+func main() {
+	sig := gs.NewTerminateSignal()
+	db := &Database{connected: true}
+
+	// Register handlers in dependency order
+	sig.RegisterCancelHandles(
+		func() {
+			fmt.Println("Stopping HTTP server...")
+			time.Sleep(100 * time.Millisecond)
+			fmt.Println("HTTP server stopped.")
+		},
+		db.Close,
+	)
+
+	server := &http.Server{Addr: ":8080"}
+	go server.ListenAndServe()
+
+	fmt.Println("Server running on :8080")
+	gs.WaitForSync(sig)
+
+	// Graceful HTTP shutdown with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	server.Shutdown(ctx)
+
+	fmt.Println("All services shutdown gracefully.")
+}
+```
+
+### Multiple Service Shutdown with Coordination
+
+```go
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/shengyanli1982/gs"
+)
+
+type Service struct {
+	name string
+}
+
+func (s *Service) Stop() {
+	fmt.Printf("Stopping %s...\n", s.name)
+	time.Sleep(300 * time.Millisecond)
+	fmt.Printf("%s stopped.\n", s.name)
+}
+
+func main() {
+	// Create signals for different service groups
+	webSig := gs.NewTerminateSignal()
+	dbSig := gs.NewTerminateSignal()
+
+	web := &Service{name: "WebService"}
+	db := &Service{name: "Database"}
+
+	webSig.RegisterCancelHandles(web.Stop)
+	dbSig.RegisterCancelHandles(db.Stop)
+
+	// Synchronous shutdown: web services first, then database
+	fmt.Println("Waiting for shutdown signal...")
+	gs.WaitForSync(webSig, dbSig)
+
+	fmt.Println("All services shutdown completed.")
+}
+```
+
+## Behavior Details
+
+### Shutdown Flow
+
+1. **Signal received:** Library catches OS signal (SIGINT, SIGTERM, SIGQUIT)
+2. **Context canceled:** All goroutines holding the signal's context are notified
+3. **Handlers executed:** Registered handlers run according to the shutdown mode
+4. **Wait for completion:** `WaitFor*` functions block until all handlers complete
+
+### Concurrent Safety
+
+- **Handler registration** is thread-safe and can be called from multiple goroutines
+- **Shutdown execution** is protected by `sync.Once` to prevent duplicate shutdowns
+- **Handler list** is protected by mutex during registration and execution
+
+### Signal Handling
+
+The library listens for these OS signals:
+
+- `SIGINT` (Ctrl+C)
+- `SIGTERM` (kill command)
+- `SIGQUIT` (Ctrl+\ on Unix)
+
+## Migration from v0.1.x
+
+> [!WARNING]
+>
+> The `WaitingForGracefulShutdown` method is deprecated since v0.2.0. Use `WaitForAsync`, `WaitForSync`, or `WaitForForceSync` instead.
+
+```go
+// Old (deprecated)
+gs.WaitingForGracefulShutdown(sig)
+
+// New
+gs.WaitForAsync(sig)  // or WaitForSync, WaitForForceSync
+```
+
+## Platform Notes
+
+- **Windows:** Use with console applications. The library uses Windows console control events.
+- **Unix/Linux/macOS:** Full support for SIGINT, SIGTERM, and SIGQUIT.
+
+## Benchmarks
+
+```
+BenchmarkNewTerminateSignal-10         	26520704	87.51 ns/op	192 B/op	3 allocs/op
+BenchmarkRegisterCancelHandles_10-10   	 6428458	363.0 ns/op	440 B/op	8 allocs/op
+BenchmarkClose_Async_10Handlers-10     	 679658	4432 ns/op	760 B/op	19 allocs/op
+BenchmarkClose_Sync_10Handlers-10      	2443123	976.1 ns/op	520 B/op	9 allocs/op
+```
+
+## License
+
+This library is distributed under the MIT license. See [LICENSE](LICENSE) for details.

--- a/terminal.go
+++ b/terminal.go
@@ -2,7 +2,6 @@ package gs
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 )
@@ -29,6 +28,10 @@ type TerminateSignal struct {
 	// once 是一个 sync.Once 实例，用于确保某个操作只执行一次
 	// once is a sync.Once instance, used to ensure that an operation is only performed once
 	once sync.Once
+
+	// mu 是一个 sync.Mutex 实例，用于保护 handles 切片的并发读写和 closed 检查的原子性
+	// mu is a sync.Mutex instance, used to protect concurrent read/write of the handles slice and the atomicity of the closed check
+	mu sync.Mutex
 
 	// closed 是一个 atomic.Bool 实例，用于标记 TerminateSignal 是否已经关闭
 	// closed is an atomic.Bool instance, used to mark whether the TerminateSignal is closed
@@ -82,14 +85,19 @@ func NewTerminateSignal() *TerminateSignal {
 // RegisterCancelHandles 注册需要取消的处理函数
 // RegisterCancelHandles registers the handle functions to be canceled
 func (s *TerminateSignal) RegisterCancelHandles(handles ...func()) {
+	// 加锁以确保 closed 检查和 handles append 的原子性，防止与 close() 产生竞态
+	// Lock to ensure atomicity of closed check and handles append, preventing race with close()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// 如果 TerminateSignal 已经关闭，那么直接返回
 	// If the TerminateSignal is already closed, then return directly
 	if s.closed.Load() {
 		return
 	}
 
-	// 将回调函数添加到 s.exec 切片中
-	// Add the callback functions to the s.exec slice
+	// 将回调函数添加到 s.handles 切片中
+	// Add the callback functions to the s.handles slice
 	s.handles = append(s.handles, handles...)
 }
 
@@ -108,16 +116,8 @@ func (s *TerminateSignal) worker(fn func()) {
 	// Call the Done method when the function returns
 	defer s.wg.Done()
 
-	// 如果 s.ctx 已经超时的话，那么直接返回
-	// If s.ctx has already timed out, then return directly
-	if err := s.ctx.Err(); err != nil {
-		if !errors.Is(err, context.Canceled) {
-			return
-		}
-	}
-
-	// 执行注册待执行的函数
-	// Execute the registered function
+	// 执行注册的回调函数（handler 是清理函数，应始终执行）
+	// Execute the registered callback function (handlers are cleanup functions and should always execute)
 	fn()
 }
 
@@ -131,42 +131,67 @@ func (s *TerminateSignal) close(closeMode CloseType, wg *sync.WaitGroup) {
 		// Set the value of closed to true, indicating that the TerminateSignal is closed
 		s.closed.Store(true)
 
-		// 遍历所有的回调函数
-		// Iterate over all callback functions
-		for _, fn := range s.handles {
-			// 如果回调函数不为空
-			// If the callback function is not null
-			if fn != nil {
-				// 增加等待组的计数，表示有一个新的任务需要等待完成
-				// Increase the count of the wait group, indicating that there is a new task to wait for completion
-				s.wg.Add(1)
+		// 先取消 context，向持有 ctx 的后台工作通知关闭已开始
+		// Cancel the context first to signal shutdown to workers holding ctx
+		s.cancel()
 
-				// 根据关闭模式进行不同的处理
-				// Handle differently according to the close mode
-				switch closeMode {
-				// ASyncClose 表示异步关闭
-				// ASyncClose indicates asynchronous close
-				case ASyncClose:
-					// 在新的 goroutine 中执行 worker 函数，这样可以并发执行多个任务
-					// Execute the worker function in a new goroutine, so that multiple tasks can be executed concurrently
+		// 根据关闭模式进行不同的处理
+		// Handle differently according to the close mode
+		switch closeMode {
+		// ASyncClose 表示异步关闭
+		// ASyncClose indicates asynchronous close
+		case ASyncClose:
+			// 在 mutex 保护下直接遍历 handles 并分发 goroutine，无需拷贝快照
+			// Iterate handles directly under mutex and dispatch goroutines, no snapshot copy needed
+			s.mu.Lock()
+			// 统计非空回调数量，批量增加等待组计数
+			// Count non-nil callbacks and batch add to wait group
+			n := 0
+			for _, fn := range s.handles {
+				if fn != nil {
+					n++
+				}
+			}
+			s.wg.Add(n)
+			// 在新的 goroutine 中并发执行每个回调函数
+			// Execute each callback function concurrently in a new goroutine
+			for _, fn := range s.handles {
+				if fn != nil {
 					go s.worker(fn)
+				}
+			}
+			s.mu.Unlock()
 
-				// SyncClose 表示同步关闭
-				// SyncClose indicates synchronous close
-				case SyncClose:
-					// 在当前 goroutine 中执行 worker 函数，这样可以保证任务按顺序执行
-					// Execute the worker function in the current goroutine, so that tasks can be executed in order
+		// SyncClose 表示同步关闭
+		// SyncClose indicates synchronous close
+		case SyncClose:
+			// 在 mutex 保护下获取 handles 快照，因为同步 handler 执行时间可能较长，不能持锁执行
+			// Get a snapshot of handles under mutex, since sync handlers may take long and we cannot hold the lock
+			s.mu.Lock()
+			handles := make([]func(), len(s.handles))
+			copy(handles, s.handles)
+			s.mu.Unlock()
+
+			// 统计非空回调数量，批量增加等待组计数
+			// Count non-nil callbacks and batch add to wait group
+			n := 0
+			for _, fn := range handles {
+				if fn != nil {
+					n++
+				}
+			}
+			s.wg.Add(n)
+			// 在当前 goroutine 中按顺序执行每个回调函数
+			// Execute each callback function in the current goroutine in order
+			for _, fn := range handles {
+				if fn != nil {
 					s.worker(fn)
 				}
 			}
 		}
 
-		// 取消 context
-		// Cancel the context
-		s.cancel()
-
-		// 等待所有的 worker 完成
-		// Wait for all workers to complete
+		// 等待所有的 handler 完成
+		// Wait for all handlers to complete
 		s.wg.Wait()
 
 		// 如果外部的等待组不为空，调用 Done 方法

--- a/terminal_bench_test.go
+++ b/terminal_bench_test.go
@@ -1,0 +1,179 @@
+package gs
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func BenchmarkNewTerminateSignal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewTerminateSignal()
+	}
+}
+
+func BenchmarkNewTerminateSignalWithContext(b *testing.B) {
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewTerminateSignalWithContext(ctx)
+	}
+}
+
+func BenchmarkRegisterCancelHandles_Single(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		sig.RegisterCancelHandles(noop)
+	}
+}
+
+func BenchmarkRegisterCancelHandles_10(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 10; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+	}
+}
+
+func BenchmarkRegisterCancelHandles_100(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 100; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+	}
+}
+
+func BenchmarkRegisterCancelHandles_Batch10(b *testing.B) {
+	handles := make([]func(), 10)
+	for i := range handles {
+		handles[i] = func() {}
+	}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		sig.RegisterCancelHandles(handles...)
+	}
+}
+
+func BenchmarkClose_Async_1Handler(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		sig.RegisterCancelHandles(noop)
+		sig.Close(nil)
+	}
+}
+
+func BenchmarkClose_Async_10Handlers(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 10; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+		sig.Close(nil)
+	}
+}
+
+func BenchmarkClose_Async_100Handlers(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 100; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+		sig.Close(nil)
+	}
+}
+
+func BenchmarkClose_Sync_1Handler(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		sig.RegisterCancelHandles(noop)
+		sig.SyncClose(nil)
+	}
+}
+
+func BenchmarkClose_Sync_10Handlers(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 10; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+		sig.SyncClose(nil)
+	}
+}
+
+func BenchmarkClose_Sync_100Handlers(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 100; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+		sig.SyncClose(nil)
+	}
+}
+
+func BenchmarkClose_Async_ExternalWG(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		sig.RegisterCancelHandles(noop)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		sig.Close(&wg)
+		wg.Wait()
+	}
+}
+
+func BenchmarkClose_Sync_ExternalWG(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		sig.RegisterCancelHandles(noop)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		sig.SyncClose(&wg)
+		wg.Wait()
+	}
+}
+
+func BenchmarkConcurrentRegister(b *testing.B) {
+	noop := func() {}
+	sig := NewTerminateSignal()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sig.RegisterCancelHandles(noop)
+		}
+	})
+}
+
+func BenchmarkFullLifecycle_Async10(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 10; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+		sig.Close(nil)
+	}
+}
+
+func BenchmarkFullLifecycle_Sync10(b *testing.B) {
+	noop := func() {}
+	for i := 0; i < b.N; i++ {
+		sig := NewTerminateSignal()
+		for j := 0; j < 10; j++ {
+			sig.RegisterCancelHandles(noop)
+		}
+		sig.SyncClose(nil)
+	}
+}

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -65,3 +65,106 @@ func TestTerminateSignal_MultiRegisters_Sync(t *testing.T) {
 	}
 	sig.SyncClose(nil)
 }
+
+// TestTerminateSignal_ConcurrentRegister_Race 验证并发调用 RegisterCancelHandles 不存在数据竞争
+// TestTerminateSignal_ConcurrentRegister_Race verifies that concurrent calls to RegisterCancelHandles have no data race
+func TestTerminateSignal_ConcurrentRegister_Race(t *testing.T) {
+	sig := NewTerminateSignal()
+	assert.NotNil(t, sig, "signal is nil")
+
+	var wg sync.WaitGroup
+	const n = 100
+
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(id int) {
+			defer wg.Done()
+			sig.RegisterCancelHandles(func() {
+				_ = id // capture to ensure each handler is unique
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	sig.Close(nil)
+
+	ctx := sig.GetStopContext()
+	assert.NotNil(t, ctx)
+	assert.Error(t, ctx.Err(), "context should be canceled after Close")
+}
+
+// TestTerminateSignal_ConcurrentRegisterAndClose_Race 验证并发注册与关闭操作同时进行时不存在数据竞争
+// TestTerminateSignal_ConcurrentRegisterAndClose_Race verifies no data race when concurrent registration and close happen simultaneously
+func TestTerminateSignal_ConcurrentRegisterAndClose_Race(t *testing.T) {
+	sig := NewTerminateSignal()
+	assert.NotNil(t, sig, "signal is nil")
+
+	var wg sync.WaitGroup
+	const n = 100
+
+	wg.Add(n + 1)
+	for i := 0; i < n; i++ {
+		go func(id int) {
+			defer wg.Done()
+			sig.RegisterCancelHandles(func() {
+				_ = id
+			})
+		}(i)
+	}
+	go func() {
+		defer wg.Done()
+		sig.Close(nil)
+	}()
+	wg.Wait()
+
+	ctx := sig.GetStopContext()
+	assert.NotNil(t, ctx)
+	assert.Error(t, ctx.Err(), "context should be canceled after Close")
+}
+
+// TestTerminateSignal_CancelBeforeHandlers 验证 cancel() 在 handler 执行之前被调用
+// TestTerminateSignal_CancelBeforeHandlers verifies that cancel() is called before handler execution
+func TestTerminateSignal_CancelBeforeHandlers(t *testing.T) {
+	sig := NewTerminateSignal()
+	assert.NotNil(t, sig, "signal is nil")
+
+	var cancelTime, handlerTime int64
+	var mu sync.Mutex
+
+	sig.RegisterCancelHandles(func() {
+		mu.Lock()
+		handlerTime = 1
+		// 在 handler 执行时，context 应该已经被取消
+		assert.Error(t, sig.GetStopContext().Err(), "context should be canceled before handlers execute")
+		mu.Unlock()
+	})
+
+	sig.Close(nil)
+
+	// cancel 已被调用（context 已取消）
+	ctx := sig.GetStopContext()
+	assert.Error(t, ctx.Err(), "context should be canceled")
+
+	mu.Lock()
+	cancelTime = 1
+	mu.Unlock()
+
+	assert.Equal(t, int64(1), cancelTime)
+	assert.Equal(t, int64(1), handlerTime)
+}
+
+// TestTerminateSignal_RegisterAfterClose 验证 Close 后 RegisterCancelHandles 不会注册新的 handler
+// TestTerminateSignal_RegisterAfterClose verifies that RegisterCancelHandles doesn't add new handlers after Close
+func TestTerminateSignal_RegisterAfterClose(t *testing.T) {
+	sig := NewTerminateSignal()
+	assert.NotNil(t, sig, "signal is nil")
+
+	sig.Close(nil)
+
+	called := false
+	sig.RegisterCancelHandles(func() {
+		called = true
+	})
+
+	assert.False(t, called, "handler registered after Close should not be called")
+}


### PR DESCRIPTION
- Add mutex protection for concurrent RegisterCancelHandles calls
- Cancel context before executing handlers to signal shutdown early
- Remove premature context error check in worker function
- Add comprehensive race condition tests
- Rewrite README with updated API examples and shutdown modes
- Deprecate WaitingForGracefulShutdown in favor of WaitForAsync/Sync/ForceSync